### PR TITLE
Change column definition to use BINARY(16) for UUID types

### DIFF
--- a/src/main/kotlin/br/com/amz/peekpay/persistence/customer/Customer.kt
+++ b/src/main/kotlin/br/com/amz/peekpay/persistence/customer/Customer.kt
@@ -11,9 +11,10 @@ import javax.persistence.Table
 @Entity
 @Table(name = "customers")
 data class Customer (
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(nullable = false, updatable = false, unique = true)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false, unique = true)
     val id: UUID = UUID.randomUUID(),
 
     val email: String

--- a/src/main/kotlin/br/com/amz/peekpay/persistence/order/Order.kt
+++ b/src/main/kotlin/br/com/amz/peekpay/persistence/order/Order.kt
@@ -21,7 +21,7 @@ import javax.persistence.Table
 data class Order (
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(nullable = false, updatable = false, unique = true)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false, unique = true)
     val id: UUID = UUID.randomUUID(),
 
     @OneToOne

--- a/src/main/kotlin/br/com/amz/peekpay/persistence/payment/Payment.kt
+++ b/src/main/kotlin/br/com/amz/peekpay/persistence/payment/Payment.kt
@@ -18,7 +18,7 @@ import javax.persistence.Table
 data class Payment (
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(nullable = false, updatable = false, unique = true)
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false, unique = true)
     val id: UUID = UUID.randomUUID(),
 
     @Column(nullable = false)
@@ -28,6 +28,6 @@ data class Payment (
     @JoinColumn(name="order_id")
     val order: Order,
 
-    @Column(name = "idempotency_key", updatable = false, unique = true)
+    @Column(columnDefinition = "BINARY(16)", name = "idempotency_key", updatable = false, unique = true)
     val idempotencyKey: UUID? = null
 )


### PR DESCRIPTION
### Context

During some integration test's execution, we could seed an error as follows:
```
Caused by: org.h2.jdbc.JdbcSQLDataException: Value too long for column "ID BINARY": "CAST(X'valid-uuid-example-here' AS BINARY(16)) (16)"
```

This error was caused basically due to a type definition for UUID columns, where the JDBC side created it as a `BINARY (16)` type, and in the meanwhile, Hibernate wasn't using the same type definition, which stored a higher value size than the JDBC's one.

### How this PR solves the problem?

It simply adds the attribute `columnDefinition` from `@Column` annotation, and it sets the value `BINARY(16)` to "sync" the same type as JDBC uses.